### PR TITLE
Updates to API docs

### DIFF
--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -668,7 +668,7 @@ GET /1.0/my-database/my-collection
 
 ### Content-type header
 
-In almost all cases, the `Content-Type` header should be `application/json`. API contains some internal endpoints which allow `text/plain` but all interaction using the above endpoints you should use `application/json`.
+In almost all cases, the `Content-Type` header should be `application/json`. API contains some internal endpoints which allow `text/plain` but for all interaction using the above endpoints you should use `application/json`.
 
 ### Authorization header
 
@@ -1933,19 +1933,57 @@ And then enable it in a model:
 
 ### Hello
 
-The *Hello* endpoint returns a plain text response with the string *Welcome to API* when a `GET` request is made to the `/hello` endpoint. It can be used to verify that DADI API was successfully installed.
+The *Hello* endpoint returns a plain text response with the string *Welcome to API* when a `GET` request is made to the `/hello` endpoint. It can be used to verify that DADI API is successfully installed and running. You should expect a 200 status code to be returned when requesting this endpoint.
 
 ### Configuration
 
-[TODO]
+The `/api/config` endpoint returns a JSON response with API's current configuration. This endpoint requires authentication by passing a Bearer token in the Authorization header. See the [Authentication](#authentication) section for more detail.
+
+```http
+GET /api/config HTTP/1.1
+Host: api.somedomain.tech
+Content-Type: application/json
+Cache-Control: no-cache
+```
 
 ### Cache flush
 
-[TODO]
+Cached files can be flushed by sending a `POST` request to API's `/api/flush` endpoint. The request body must contain a path that matches a collection resource. For example, the following will flush all cache files that match the collection path `/1.0/library/books`.
+
+```http
+POST /api/flush HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+{ "path": "/1.0/library/books" }
+```
+
+A successful cache flush returns a JSON response with a 200 status code:
+
+```json
+{
+  "result": "success",
+  "message": "Cache flush successful"
+}
+```
+
+#### Flush all files
+
+To flush all cache files from the API's caching layer, send `*` as the path in the request body:
+
+```http
+POST /api/flush HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+{ "path": "*" }
+```
 
 ### All Collections
 
-A document containing information about the available collections can be retrieved by sending a `GET` request to the API's `/api/collections` endpoint.
+The `/api/collections` endpoint returns a JSON response containing information about the available collections that can be queried.
 
 ```http
 GET /api/collections HTTP/1.1

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -699,7 +699,7 @@ Host: api.somedomain.tech
 
 ```json
 {
-  results: [
+  "results": [
     "_id": "5ae1b6464e0b766dd17dbab9"
     "_apiVersion": "1.0",
     "_createdAt": 1511875141,

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -102,7 +102,7 @@ The `accessType` property accepts one of two values: `admin` or `user`. An `admi
 >
 > -- advice
 
-Once you have client records in the database, you can request an access token for to continue communicating with the API. See [Obtaining an Access Token](/api#obtaining-an-access-token).
+Once you have client records in the database, you can request an access token for to continue communicating with the API. See [Obtaining an Access Token](#obtaining-an-access-token).
 
 ### Adding Clients
 
@@ -337,7 +337,7 @@ All requests to collection and custom endpoints must include the version in the 
 
 Collection documents may be stored in separate databases in the underlying data store, represented by the name of the "database" directory.
 
-> **Note** This feature is disabled by default. To enable separate databases in your API the configuration setting `database.enableCollectionDatabases` must be `true`. See [Collection-specific Databases](/api#collection-specific-databases) for more information.
+> **Note** This feature is disabled by default. To enable separate databases in your API the configuration setting `database.enableCollectionDatabases` must be `true`. See [Collection-specific Databases](#collection-specific-databases) for more information.
 
 **Collection specification file**
 
@@ -458,7 +458,7 @@ Each field in a collection is defined using the following format. The only requi
 
 ### Field Types
 
-Every field in a collection must be one of the following types. All documents sent to API are validated against a collection's field type to ensure that data will be stored in the format intended. See the section on [Validation](/api#validation) for more details.
+Every field in a collection must be one of the following types. All documents sent to API are validated against a collection's field type to ensure that data will be stored in the format intended. See the section on [Validation](#validation) for more details.
 
 | Type | Description | Example
 |:--|:--|:--
@@ -502,12 +502,12 @@ Each collection specification must contain a `settings` block, even if it is emp
 | revisionCollection | The name of the collection used to hold revision documents | The collection name with "History" appended | `"authorsHistory"`
 | callback | Name of a function to use as a JSONP callback | `null` | `setAuthors`
 | defaultFilters | Specifies a default query for the collection. A `filter` parameter passed in the querystring will extend these filters.  | `{}` | `{ "published": true }`
-| fieldLimiters | Specifies a list of fields for inclusion/exclusion in the response. Fields can be included or excluded, but not both. See [Retrieving data](/api#retrieving-data) for more detail. | `{}` | `{ "title": 1, "author": 1 }`, `{ "dob": 0, "state": 0 }`
-| index | Specifies a set of indexes that should be created for the collection. See [Creating Database Indexes](/api#creating-database-indexes) for more detail. | `[]`  | `{ "keys": { "username": 1 }, "options": { "unique": true } }`
+| fieldLimiters | Specifies a list of fields for inclusion/exclusion in the response. Fields can be included or excluded, but not both. See [Retrieving data](#retrieving-data) for more detail. | `{}` | `{ "title": 1, "author": 1 }`, `{ "dob": 0, "state": 0 }`
+| index | Specifies a set of indexes that should be created for the collection. See [Creating Database Indexes](#creating-database-indexes) for more detail. | `[]`  | `{ "keys": { "username": 1 }, "options": { "unique": true } }`
 
 > **Overriding configuration using querystring parameters**
 >
-> It is possible to override some of these values when requesting data from the endpoint, by using querystring parameters. See [Querying a collection](/api#querying) for detailed documentation.
+> It is possible to override some of these values when requesting data from the endpoint, by using querystring parameters. See [Querying a collection](#querying) for detailed documentation.
 >
 > -- advice
 
@@ -675,6 +675,71 @@ In almost all cases, the `Content-Type` header should be `application/json`. API
 Unless a collection has authentication disabled, every request using the above REST endpoints will require an Authorization header containing an access token. See [Obtaining an Access Token](#obtaining-an-access-token) for more detail.
 
 ## Working with data
+
+### Retrieving data
+
+Sending a request using the `GET` method instructs API to find and retrieve all documents that match a certain criteria.
+
+There are two types of retrieval operation: one where a single document is to be retrieved and its identifier is known; and the other where one or many documents matching a query should be retrieved.
+
+#### Retrieve a single resource by ID
+
+To retrieve a document with a known identifier, add the identifier to the REST endpoint for the collection.
+
+##### Request
+
+**Format:** `GET http://api.somedomain.tech/1.0/library/books/{ID}`
+
+```http
+GET /1.0/library/books/560a44b33a4d7de29f168ce4 HTTP/1.1
+Authorization: Bearer afd4368e-f312-4b14-bd93-30f35a4b4814
+Content-Type: application/json
+Host: api.somedomain.tech
+```
+
+Retrieves the document with the identifier of `{ID}` from the specified collection (in this example `books`).
+
+#### Retrieve all documents matching a query
+
+Useful for retrieving multiple documents that have a common property or share a pattern. Include the query in the querystring using the `filter` parameter.
+
+##### Request
+
+**Format:** `GET http://api.somedomain.tech/1.0/library/books?filter={QUERY}`
+
+```http
+GET /1.0/library/books?filter={"title":{"$regex":"the"}} HTTP/1.1
+Authorization: Bearer afd4368e-f312-4b14-bd93-30f35a4b4814
+Content-Type: application/json
+Host: api.somedomain.tech
+```
+
+#### Query options
+
+When querying a collection, the following options can be supplied as URL parameters:
+
+| Property | Description | Default | Example
+|:--|:--|:--|:--
+| `compose` | Whether to resolve referenced documents | The value of `settings.compose` in the collection schema | `compose=true`
+| `count` | The maximum number of documents to be retrieved in one page | The value of `settings.count` in the collection schema | `count=30`
+| `fields` | The list of fields to include or exclude from the response. Takes an object mapping field names to either `1` or `0`, which will include or exclude the field, respectively. | The value of `settings.compose` in the collection schema | `fields={"first_name":1,"l_name":1}`
+| `filter` | A query to filter results by. See [filtering documents](#filtering-documents) for more detail. | The value of `settings.compose` in the collection schema | `fields={"first_name":1,"l_name":1}`
+| `includeHistory` | Whether to resolve history documents | `false` | `includeHistory=true`
+| `page` | The number of the page of results to retrieve | `1`  | `page=3`
+| `sort` | The sort direction to sort results by, mapping field names to either `1` or `0`, which will sort results by that field in ascending or descending order, respectively | The value of `settings.sortOrder` in the collection schema  | `sort={"first_name":1}`
+
+#### Filtering documents
+
+DADI API uses a MongoDB-style format for querying objects, introducing a series of operators that allow powerful queries to be assembled.
+
+| Syntax | Description | Example
+|:--|:--|:--
+| `{field: value}` | Strict comparison. Matches documents where the value of `field` is exactly `value` | `{"first_name":"John"}`
+| `{field: {"$regex": value}}` | Matches documents where the value of `field` matches a regular expression defined as `/value/i` | `{"first_name":{"$regex":John"}}`
+| `{field: {"$in":[value1,value2]}}` | Matches documents where the value of `field` is one of `value1` and `value2` | `{"last_name":{"$in":["Doe","Spencer","Appleseed"]}}`
+| `{field: {"$containsAny":[value1,value2]}}` | Matches documents where the value of `field` (an array) contains one of `value1` and `value2` | `{"tags":{"$containsAny":["dadi","dadi-api","restful"]}}`
+| `{field: {"$gt": value}}` | Matches documents where the value of `field` is greater than `value` | `{"height":{"gt":175}}`
+| `{field: {"$lt": value}}` | Matches documents where the value of `field` is less than `value` | `{"weight":{"lt":85}}`
 
 ### Inserting data
 
@@ -892,7 +957,7 @@ Updates all documents that match the results of the `query` in the specified col
 
 ### Deleting data
 
-Sending a request using the DELETE method instructs API to perform a delete operation on the documents that match the supplied parameters.
+Sending a request using the `DELETE` method instructs API to perform a delete operation on the documents that match the supplied parameters.
 
 There are two types of delete operation: one where a single document is to be deleted and its identifier is known; and the other where one or many documents matching a query should be deleted.
 
@@ -957,10 +1022,6 @@ Where `deletedCount` is the number of documents deleted and `totalCount` the num
 
 > In versions of API prior to 3.0, only the `status` and `message` fields are returned in the response.
 > -- warning
-
-### Retrieving data
-
-[TODO]
 
 ### Using Models directly
 
@@ -1982,10 +2043,10 @@ Sample repository at https://github.com/dadi/api-connector-template.
 
 The `@dadi/apidoc` package provides a set of auto-generated documentation for your API installation, reading information from the collection schemas and custom endpoints to describe the available HTTP methods and parameters required to interact with the API.
 
-* [Generating Code Snippets](/api#generating-code-snippets)
-* [Documenting custom endpoints](/api#documenting-custom-endpoints)
-* [Showing useful example values](/api#showing-useful-example-values)
-* [Excluding Collections, Endpoints and Fields](/api#excluding-collections-endpoints-and-fields)
+* [Generating Code Snippets](#generating-code-snippets)
+* [Documenting custom endpoints](#documenting-custom-endpoints)
+* [Showing useful example values](#showing-useful-example-values)
+* [Excluding Collections, Endpoints and Fields](#excluding-collections-endpoints-and-fields)
 
 #### Installation steps
 

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -1676,7 +1676,7 @@ Different types of hooks are executed at different points in the lifecycle of a 
 
 These hook types are then applied to each of the CRUD operations (e.g. `beforeCreate`, `afterCreate`, etc.). If you think of API as an assembly line that processes requests and documents, this is where hooks would sit:
 
-```
+```text
          ______________          __________            _____________ 
 Request |              |        |          | Response |             |
 ------> | beforeCreate | -----> | Database | -------> | afterCreate |
@@ -1691,7 +1691,7 @@ Hooks are expected to export a function that receives three parameters:
 1. The name of the hook type (type: `String`, example: `"beforeCreate"`)
 1. An object with additional data that varies with each hook type (type: `Object`)
 
-##### `beforeCreate`
+##### beforeCreate
 
 Fires for `POST` requests, before documents are inserted into the database.
 
@@ -1709,7 +1709,7 @@ Fires for `POST` requests, before documents are inserted into the database.
 
 The new set of documents to be inserted. An error can be thrown to abort the operation.
 
-##### `afterCreate`
+##### afterCreate
 
 Fires for `POST` requests, if and after the documents have been successfully inserted.
 
@@ -1726,7 +1726,7 @@ Fires for `POST` requests, if and after the documents have been successfully ins
 
 N/A
 
-##### `beforeDelete`
+##### beforeDelete
 
 Fires for `DELETE` requests, before data is deleted from the database.
 
@@ -1745,7 +1745,7 @@ Fires for `DELETE` requests, before data is deleted from the database.
 
 The new query to filter documents with. An error can be thrown to abort the operation.
 
-##### `afterDelete`
+##### afterDelete
 
 Fires for `DELETE` requests, if and after the documents have been successfully deleted.
 
@@ -1763,7 +1763,7 @@ Fires for `DELETE` requests, if and after the documents have been successfully d
 
 N/A
 
-##### `beforeGet`
+##### beforeGet
 
 Fires for `GET` requests, before documents are retrieved from the database.
 
@@ -1781,7 +1781,7 @@ Fires for `GET` requests, before documents are retrieved from the database.
 
 The new query to filter documents with. An error can be thrown to abort the operation.
 
-##### `afterGet`
+##### afterGet
 
 Fires for `GET` requests. Unlike other *after* hooks, *afterGet* happens after the data has been retrieved but before the response is sent to the consumer. As a consequence, *afterGet* hooks have the ability to massage the data before it's delivered.
 
@@ -1799,7 +1799,7 @@ Fires for `GET` requests. Unlike other *after* hooks, *afterGet* happens after t
 
 The result set formatted for output. An error can be thrown to abort the operation.
 
-##### `beforeUpdate`
+##### beforeUpdate
 
 Fires for `PUT` requests, before documents are updated on the database.
 
@@ -1818,7 +1818,7 @@ Fires for `PUT` requests, before documents are updated on the database.
 
 The new update object. An error can be thrown to abort the operation.
 
-##### `afterUpdate`
+##### afterUpdate
 
 Fires for `PUT` requests, if and after the documents have been successfully updated.
 

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -2037,7 +2037,36 @@ Sample repository at https://github.com/dadi/api-connector-template.
 
 ### Connecting to API with API wrapper
 
-[TODO]
+When consuming data from DADI API programmatically from a JavaScript application, you can use [DADI API wrapper](https://github.com/dadi/api-wrapper) as a high-level API to build your requests, allowing you to abstract most of the formalities around building an HTTP request and setting the right headers for the content type and authentication.
+
+In the example below, we can see how you could connect to an instance of DADI API and retrieve all the documents that match a certain query, which you can define using a [set of filters](https://github.com/dadi/api-wrapper#filters) that use a natural, conversational syntax.
+
+```js
+const DadiAPI = require('@dadi/api-wrapper')
+
+let api = new DadiAPI({
+  uri: 'https://api.somedomain.tech',
+  port: 80,
+  credentials: {
+    clientId: 'johndoe',
+    secret: 'f00b4r'
+  },
+  version: '1.0',
+  database: 'my-db'
+})
+
+// Example: getting all documents where `name` contains "john" and age is greater than 18
+api.in('users')
+ .whereFieldContains('name', 'john')
+ .whereFieldIsGreaterThan('age', 18)
+ .find()
+ .then(({metadata, results}) => {
+   // Use documents here
+   processData(results)
+ })
+```
+
+For more information about API wrapper, including a comprehensive list of its filters and terminator functions, check the [GitHub repository](https://github.com/dadi/api-wrapper).
 
 ### Auto generate documentation
 

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -79,7 +79,8 @@ my-api/
 DADI API provides a full-featured authentication layer based on the [Client Credentials flow of oAuth 2.0](http://oauthbible.com/#oauth-2-two-legged). By default all requests to collection endpoints in API require a user to have first been authenticated. Read the following to learn what's involved in authenticating against your DADI API.
 
 ### Client Store
-At the heart of API's authentication mechanism is an internal "client store" collection. The default name for this collection is `clientStore` but this can be modified using the configuration property [`auth.clientCollectionName`](#x).
+
+At the heart of API's authentication mechanism is an internal "client store" collection. The default name for this collection is `clientStore` but this can be modified using the configuration property `auth.clientCollectionName`.
 
 The client store collection holds information about "clients" that are able to connect to the API. Think of a client as your website, mobile application or any application that should be allowed to access your API. The client credentials are used to obtain access tokens for communicating with the API.
 
@@ -105,7 +106,7 @@ Once you have client records in the database, you can request an access token fo
 
 ### Adding Clients
 
-If you've installed [DADI CLI](/cli) you can use that to create a new client in the database. See instructions for [Adding Clients with CLI](#x).
+If you've installed [DADI CLI](/cli) you can use that to create a new client in the database. See instructions for [Adding Clients with CLI](/cli#api-clientsadd).
 
 Alternatively, use the built in NPM script to start the Client Record Generator which will present you with a series of questions about the new client and insert a record into the configured database.
 
@@ -124,7 +125,7 @@ $ npm explore @dadi/api -- npm run create-client
 
 ### Collection Authentication
 
-Each [collection specification](#x) contains a "settings" block which modifies certain aspects of the collection. The [`settings.authenticate`](#x) property can be used in the following ways.
+Each [collection specification](#the-json-file) contains a "settings" block which modifies certain aspects of the collection. The [`settings.authenticate`](#collection-settings) property can be used in the following ways.
 
 To specify that authentication for the collection is:
 
@@ -140,7 +141,7 @@ The following configuration for a collection will allow all GET requests to proc
 }
 ```
 
-See [more information about collection specifications and their configuration](#x).
+See [more information about collection specifications and their configuration](#collections).
 
 ### Obtaining an Access Token
 
@@ -256,7 +257,7 @@ Add a permissions block containing an array of the collections and/or an array o
 
 #### API Version Access Control
 
-It is also possible to restrict access to versions of your API (see [API Versioning](/api#api-versioning) for more information). Add an `apiVersion` property to the collection or endpoint permission:
+It is also possible to restrict access to versions of your API (see [API Versioning](#api-versioning) for more information). Add an `apiVersion` property to the collection or endpoint permission:
 
 ```json
 {
@@ -326,8 +327,11 @@ my-api/
 
 **API Version**
 
-Specific versions of your API are represented by "version" folders within the collections folder.
-[MORE]
+Specific versions of your API are represented as sub-directories of the collections directory. Versioning of collections and endpoints acts as a formal contract between the API and its consumers.
+
+Imagine a situation where a breaking change needs to be introduced — e.g. adding or removing a collection field, or changing the output format of an endpoint. A good way to handle this would be to introduce the new structure as version 2.0 and retain the old one as version 1.0, warning consumers of its deprecation and potentially giving them a window of time before the functionality is removed.
+
+All requests to collection and custom endpoints must include the version in the URL, mimicking the hierarchy defined in the folder structure.
 
 **Database**
 
@@ -379,14 +383,14 @@ With the above directory structure API will generate this REST endpoint: https:/
 
 ### The JSON File
 
-Collection specification files can be created and edited in any text editor, then added to the API's `collections` directory. API will load all valid collections when it is restarted.
+Collection specification files can be created and edited in any text editor, then added to the API's `collections` directory. API will load all valid collections when it boots.
 
 #### Minimum Requirements
 
 The JSON file must contain a `fields` property and a `settings` property.
 
-* `fields`: must contain at least one field specification. See [Collection Fields](api#collection-fields) for the format of fields.
-* `settings`: a `settings` block must be provided, even if it's empty. API uses sensible defaults for collection configuration, but these can be overridden using properties in the `settings` block. See [Collection Settings](/api#collection-settings) for details.
+* `fields`: must contain at least one field specification. See [Collection Fields](#collection-fields) for the format of fields.
+* `settings`: a `settings` block must be provided, even if it's empty. API uses sensible defaults for collection configuration, but these can be overridden using properties in the `settings` block. See [Collection Settings](#collection-settings) for details.
 
 **A skeleton collection specification**
 
@@ -464,7 +468,7 @@ Every field in a collection must be one of the following types. All documents se
 | Object | Accepts single JSON documents or an array of documents | `{ "firstName": "Steve" }`
 | Mixed | Can accept any of the above types: String, Number, Boolean or Object |
 | ObjectID | **Deprecated** Accepts MongoDB ObjectIds | `560a5baf320039f7d6a78d3b`
-| Reference | Used for linking documents in the same collection or a different collection, solving the problem of storing subdocuments in documents. See [Document Composition (reference fields)](api#document-composition) for further information. | the ID of another document as a String: `"560a5baf320039f7d6a78d3b"`
+| Reference | Used for linking documents in the same collection or a different collection, solving the problem of storing subdocuments in documents. See [Document Composition (reference fields)](#document-composition) for further information. | the ID of another document as a String: `"560a5baf320039f7d6a78d3b"`
 
 
 ### Collection Settings
@@ -496,7 +500,7 @@ Each collection specification must contain a `settings` block, even if it is emp
 | sortOrder | The sort direction to sort results by | `1`  | `1` = ascending, `-1` = descending
 | storeRevisions | If true, every change to a document will cause the previous version to be saved to a revision/history collection | `true` | `false`
 | revisionCollection | The name of the collection used to hold revision documents | The collection name with "History" appended | `"authorsHistory"`
-| callback | x | x | x
+| callback | Name of a function to use as a JSONP callback | `null` | `setAuthors`
 | defaultFilters | Specifies a default query for the collection. A `filter` parameter passed in the querystring will extend these filters.  | `{}` | `{ "published": true }`
 | fieldLimiters | Specifies a list of fields for inclusion/exclusion in the response. Fields can be included or excluded, but not both. See [Retrieving data](/api#retrieving-data) for more detail. | `{}` | `{ "title": 1, "author": 1 }`, `{ "dob": 0, "state": 0 }`
 | index | Specifies a set of indexes that should be created for the collection. See [Creating Database Indexes](/api#creating-database-indexes) for more detail. | `[]`  | `{ "keys": { "username": 1 }, "options": { "unique": true } }`
@@ -583,7 +587,7 @@ Content-Length: 57
 
 > **Note**
 >
-> To create or edit collection specifications using the configuration endpoints, you must use an access token obtained by using credentials for a client with an `accessType` of "admin". See the [Authentication](/api#authentication) section for more detail.
+> To create or edit collection specifications using the configuration endpoints, you must use an access token obtained by using credentials for a client with an `accessType` of "admin". See the [Authentication](#authentication) section for more detail.
 >
 > If your access token was not obtained using a set of "admin" credentials, API responds with HTTP 401 Unauthorized.
 >
@@ -638,13 +642,13 @@ Connection: close
 
 ## The REST API
 
-The primary way of interacting with DADI API is via REST endpoints that are automatically generated for each of the [collections](https://docs.dadi.tech/api/#collections) added to the application. Each REST endpoint allows you to insert, update, delete and query data stored in the underlying database.
+The primary way of interacting with DADI API is via REST endpoints that are automatically generated for each of the [collections](#collections) added to the application. Each REST endpoint allows you to insert, update, delete and query data stored in the underlying database.
 
 ### REST endpoint format
 
-`http(s)://api.somedomain.tech/{version}/{database}/{collection}`
+`http(s)://api.somedomain.tech/{version}/{database}/{collection name}`
 
-The REST endpoints follow the above format, where `{version}` is the current version of the API collections (not the installed version of API), `{database}` is the database that holds the specified collection and `{collection}` is the actual collection to interact with. See [Collections directory](/api/#collections-directory) for more detail.
+The REST endpoints follow the above format, where `{version}` is the current version of the API collections (not the installed version of API), `{database}` is the database that holds the specified collection and `{collection name}` is the actual collection to interact with. See [Collections directory](#collections-directory) for more detail.
 
 Example endpoints for each of the supported HTTP verbs:
 
@@ -668,13 +672,13 @@ In almost all cases, the `Content-Type` header should be `application/json`. API
 
 ### Authorization header
 
-Unless a collection has authentication disabled, every request using the above REST endpoints will require an Authorization header containing an access token. See [Obtaining an Access Token](/api/#obtaining-an-access-token) for more detail.
+Unless a collection has authentication disabled, every request using the above REST endpoints will require an Authorization header containing an access token. See [Obtaining an Access Token](#obtaining-an-access-token) for more detail.
 
 ## Working with data
 
 ### Inserting data
 
-Inserting data involves sending a POST request to the endpoint for the collection that will store the data. If the data passes [validation rules](https://docs.dadi.tech/api/#validation) imposed by the collection, it is inserted into the collection with a set of internal fields added.
+Inserting data involves sending a POST request to the endpoint for the collection that will store the data. If the data passes [validation rules](#validation) imposed by the collection, it is inserted into the collection with a set of internal fields added.
 
 #### Request
 
@@ -695,11 +699,14 @@ Host: api.somedomain.tech
 
 ```json
 {
-  "title": "The Old Man and the Sea",
-  "_apiVersion": "1.0",
-  "_createdAt": 1511875141,
-  "_createdBy": "your-client-id",
-  "_version": 1
+  results: [
+    "_id": "5ae1b6464e0b766dd17dbab9"
+    "_apiVersion": "1.0",
+    "_createdAt": 1511875141,
+    "_createdBy": "your-client-id",
+    "_version": 1,
+    "title": "The Old Man and the Sea"
+  ]
 }
 ```
 
@@ -753,11 +760,11 @@ Host: api.somedomain.tech
 
 Updating data with API involves sending a PUT request to the endpoint for the collection that holds the data.
 
-There are two types of update operation: one where a single document is to be updated and it's identifier is known; and the other where one or many documents matching a query should be updated.
+There are two types of update operation: one where a single document is to be updated and its identifier is known; and the other where one or many documents matching a query should be updated.
 
 In both cases, the request body must contain the required update specified as JSON.
 
-If the data passes [validation rules](https://docs.dadi.tech/api/#validation) imposed by the collection, it is updated using the specified update, and the internal fields `_lastModifiedAt`, `_lastModifiedBy` and `_version` are updated.
+If the data passes [validation rules](#validation) imposed by the collection, it is updated using the specified update, and the internal fields `_lastModifiedAt`, `_lastModifiedBy` and `_version` are updated.
 
 #### Update an existing resource
 
@@ -780,10 +787,36 @@ Host: api.somedomain.tech
 }
 ```
 
-Updates the document with the identifier of `{ID}` in the specified collection (in this example `"books"`). Applies the values from the `update` block specified in the request body.
+Updates the document with the identifier of `{ID}` in the specified collection (in this example `books`). Applies the values from the `update` block specified in the request body.
 
 ##### Response
-xxx
+
+```json
+{
+  "results": [
+    {
+      "_apiVersion": "v1",
+      "_createdAt": 1524741702962,
+      "_createdBy": "testClient",
+      "_history": [
+        "5ae1b6c24e0b766dd17dbaba"
+      ],
+      "_id": "5ae1b6464e0b766dd17dbab9",
+      "_lastModifiedAt": 1524741826339,
+      "_lastModifiedBy": "testClient",
+      "_version": 2,
+      "title": "For Whom the Bell Tolls (Kindle Edition)"
+    }
+  ],
+  "metadata": {
+    "fields": {},
+    "page": 1,
+    "offset": 0,
+    "totalCount": 1,
+    "totalPages": 1
+  }
+}
+```
 
 #### Update all documents matching a query
 
@@ -801,7 +834,9 @@ Host: api.somedomain.tech
 
 {
   "query": {
-    "title": "For Whom the Bell Tolls"
+    "title": {
+      "$regex": "the"
+    }
   },
   "update": {
     "available": false
@@ -812,13 +847,54 @@ Host: api.somedomain.tech
 Updates all documents that match the results of the `query` in the specified collection (in this example `"books"`). Applies the values from the `update` block specified in the request body.
 
 ##### Response
-x
+
+```json
+{
+  "results": [
+    {
+      "_apiVersion": "v1",
+      "_createdAt": 1524741702962,
+      "_createdBy": "testClient",
+      "_history": [
+        "5ae1b6c24e0b766dd17dbaba"
+      ],
+      "_id": "5ae1b6464e0b766dd17dbab9",
+      "_lastModifiedAt": 1524741826339,
+      "_lastModifiedBy": "testClient",
+      "_version": 2,
+      "title": "For Whom the Bell Tolls (Kindle Edition)",
+      "available": false
+    },
+    {
+      "_apiVersion": "v1",
+      "_createdAt": 1524741702962,
+      "_createdBy": "testClient",
+      "_history": [
+        "5ae1b6c24e0b766dd17dbaba"
+      ],
+      "_id": "5ae1b6464e0b766dd17dbab8",
+      "_lastModifiedAt": 1524741826339,
+      "_lastModifiedBy": "testClient",
+      "_version": 1,
+      "title": "The Old Man and the Sea",
+      "available": false
+    }
+  ],
+  "metadata": {
+    "fields": {},
+    "page": 1,
+    "offset": 0,
+    "totalCount": 2,
+    "totalPages": 1
+  }
+}
+```
 
 ### Deleting data
 
 Sending a request using the DELETE method instructs API to perform a delete operation on the documents that match the supplied parameters.
 
-There are two types of delete operation: one where a single document is to be deleted and it's identifier is known; and the other where one or many documents matching a query should be deleted.
+There are two types of delete operation: one where a single document is to be deleted and its identifier is known; and the other where one or many documents matching a query should be deleted.
 
 #### Delete an existing resource
 
@@ -835,7 +911,7 @@ Content-Type: application/json
 Host: api.somedomain.tech
 ```
 
-Deletes the document with the identifier of `{ID}` from the specified collection (in this example `"books"`).
+Deletes the document with the identifier of `{ID}` from the specified collection (in this example `books`).
 
 #### Delete all documents matching a query
 
@@ -858,7 +934,7 @@ Host: api.somedomain.tech
 }
 ```
 
-Deletes all documents that match the results of the `query` from the specified collection (in this example `"books"`).
+Deletes all documents that match the results of the `query` from the specified collection (in this example `books`).
 
 #### DELETE Response
 
@@ -866,20 +942,18 @@ The response returned for a DELETE request depends on the configuration setting 
 
 The default setting is `false`, in which case API returns an `HTTP 204 No Content` after a successful delete operation.
 
-If the setting is `true`, that is, the main configuration file contains the following setting:
-
-`"feedback": true`
-
-then a JSON object similar to the following is returned:
+If the setting is `true` – that is, the main configuration file contains `"feedback": true` – then a JSON object similar to the following is returned:
 
 ```json
 {
   status: 'success',
   message: 'Documents deleted successfully',
-  deleted: 1, // number of documents deleted
-  totalCount: 99 // remaining documents in the collection
+  deletedCount: 1,
+  totalCount: 99
 }
 ```
+
+Where `deletedCount` is the number of documents deleted and `totalCount` the number of remaining documents in the collection.
 
 > In versions of API prior to 3.0, only the `status` and `message` fields are returned in the response.
 > -- warning
@@ -888,24 +962,23 @@ then a JSON object similar to the following is returned:
 
 [TODO]
 
-
-
 ### Using Models directly
 
-When creating [custom Javacript endpoints](/api/#endpoints) it is possible to interact with the data model directly, without using the REST API.
+When creating [custom Javacript endpoints](#endpoints) or [collection hooks](#hooks) it may be useful to consume or create data, in which case it's possible to interact with the data model directly, as opposed to using the REST API, which would mean issuing an HTTP request.
 
 ```js
-// require the Model component from API
+// Require the Model component from API.
 const Model = require('@dadi/api').Model
 
-// get a reference to the "books" collection via the Model
-const books = Model('books')
+// Get a reference to the "books" collection via the Model.
+let books = Model('books')
 
-// call a method on the collection, for e.g. find(), insert(), update(), delete()
+// Call a method on the collection.
 books.find({ title: 'Harry Potter 2' }, { compose: true }, (err, results) => {
   if (err) console.log(err)
   
-  // do something with the results
+  // Do something with `results`
+  yourFunctionToProcessResults(results)
 })
 ```
 
@@ -914,13 +987,13 @@ books.find({ title: 'Harry Potter 2' }, { compose: true }, (err, results) => {
 
 Documents sent to the API with POST and PUT requests are validated at field level based on rules defined in the collection schema.
 
-Several means of data validation are supported in API, including [type validation](/api#type-validation), [mandatory field validation](/api#mandatory-field-validation), [length validation](/api#length-validation) and [regular expression validation](/api#regular-expression-validation).
+Several means of data validation are supported in API, including [type validation](#type-validation), [mandatory field validation](#mandatory-field-validation), [length validation](#length-validation) and [regular expression validation](#regular-expression-validation).
 
-While API can return default error messages when data fails validation, it is possible to customise the error messages for each field individually. See [Error Messages](/api#error-messages) below for more detail.
+While API can return default error messages when data fails validation, it is possible to customise the error messages for each field individually. See [Error Messages](#error-messages) below for more detail.
 
 #### Type Validation
 
-A field can be validated by type. DADI API will check that the value supplied for the field is the correct type as specified in the schema. Only the following JavaScript primitives are considered for type validation: `String`, `Number`, `Boolean`
+A field can be validated by type. DADI API will check that the value supplied for the field is the correct type as specified in the schema. Only the following JavaScript primitives are considered for type validation: `String`, `Number`, `Boolean`.
 
 ```json
 "fields": {
@@ -946,7 +1019,7 @@ Fields can be made mandatory by setting their `required` property to `true`. DAD
 
 #### Length Validation
 
-A field's length can be controlled by using the `minLength` and `maxLength` properties. Validation will fail if the length of the string is greater or less than the specified length limits.
+A field's length can be controlled by using the `minLength` and `maxLength` properties within the `validation` block. Validation will fail if the length of the string is greater or less than the specified length limits.
 
 ```json
 "fields": {
@@ -988,7 +1061,7 @@ A regular expression pattern can be specified for a field, which may help enforc
 
 #### Validation Response
 
-If a document fails validation an errors collection will be returned with the reasons for validation failure:
+If a document fails validation an errors collection will be returned with the reasons for validation failure.
 
 ```http
 HTTP/1.1 400 Bad Request
@@ -1034,11 +1107,13 @@ Message       | Description
 It is possible to supply a custom error message by specifying a `message` property in a field specification. For example:
 
 ```
-"title": {
-  "type": "String",
-  "required": true,
-  "example": "The Autobiography of Benjamin Franklin",
-  "message": "must contain a value"
+"fields": {
+  "title": {
+    "type": "String",
+    "required": true,
+    "example": "The Autobiography of Benjamin Franklin",
+    "message": "must contain a value"
+  }
 }
 ```
 
@@ -1049,7 +1124,7 @@ Indexes provide high performance read operations for frequently used queries and
 Database indexes can be automatically created for a collection by specifying the fields to be indexed in the `settings` block.
 An index will be created on the collection using the fields specified in the `keys` property.
 
-An index block such as `{ "keys": { "fieldName": 1 }` will create an index for the field `fieldName` using an ascending order.
+An index block such as `{ "keys": { "fieldName": 1 } }` will create an index for the field `fieldName` using an ascending order.
 The order will be reversed if the `1` is replaced with `-1`. Specifying multiple fields will create a compound index.
 
 ```json
@@ -1065,7 +1140,7 @@ The order will be reversed if the `1` is replaced with `-1`. Specifying multiple
 }
 ```
 
-Multiple indexes can be created for each collection, simply add more index blocks to the array for the `index` property.
+Multiple indexes can be created for each collection, simply by adding more index blocks to the array for the `index` property.
 
 ### Index Options
 
@@ -1086,7 +1161,7 @@ Each index also accepts an `options` property. The options available for an inde
 
 ## Document Revision History
 
-**settings.storeRevisions**
+### **settings.storeRevisions**
 
 If `settings.storeRevisions` is **true**:
 
@@ -1095,7 +1170,7 @@ If `settings.storeRevisions` is **true**:
 * a `revision document` will be stored for each subsequent update to an existing document  
 * each time a `revision document` is created, the `_id` of the `revision document` is pushed onto a `history` array of the original document
 
-**settings.revisionCollection**
+### **settings.revisionCollection**
 
 If `settings.revisionCollection` is specified, the collection's `revision collection` will be named according to the specified value, otherwise the collection's `revision collection` will take the form `{collection name}History`.
 
@@ -1110,29 +1185,27 @@ Main document stored in the collection, with revisions referenced in the history
   "_id": ObjectId("548efd7687fd8b50f3dca6e5"),
   "title": "War and Peace",
   "history": [
-    ObjectId("548efd7687fd8b50f3dca6e6"),
-    ObjectId("548efd7687fd8b50f3dca6e7")
+    "548efd7687fd8b50f3dca6e6",
+    "548efd7687fd8b50f3dca6e7"
   ]
 }
 ```
 
 `db.booksHistory.find()`
 
-Two revision documents stored in the revision collection, one created at
-the same time as the original document was created, the second created after an
-update operation to change the value of `title`:
+Two revision documents stored in the revision collection — one created at the same time as the original document was created, the second created after an update operation to change the value of `title`:
 
 ```json
 {
-  "_id": ObjectId("548efd7687fd8b50f3dca6e6"),
+  "_id": "548efd7687fd8b50f3dca6e6",
   "title": "Draft"
 }
 
 {
-  "_id": ObjectId("548efd7687fd8b50f3dca6e7"),
+  "_id": "548efd7687fd8b50f3dca6e7",
   "title": "War and Peace",
   "history": [
-    ObjectId("548efd7687fd8b50f3dca6e6")
+    "548efd7687fd8b50f3dca6e6"
   ]
 }
 ```
@@ -1234,10 +1307,10 @@ GET /1.0/library/books?filter={"_id":"560a5baf320039f7d6a78d3b"}&compose=true
 ```
 
 ```js
-const books = model('books')
+let books = model('books')
 
 books.find({ title: 'Harry Potter 2' }, { compose: true }, (err, result) => {
-  // do something with result
+  // do something with `result`
 })
 ```
 
@@ -1254,7 +1327,7 @@ This setting will allow the first level of Reference fields to be resolved. To a
 ```
 
 
-**a `book` document**
+**A `book` document**
 
 ```json
 [
@@ -1376,11 +1449,11 @@ An example response:
 
 ### Endpoints
 
-DADI API custom endpoints give you the ability to modify, enrich and massage your data before it is returned to the user making the request. Collection endpoints return raw data in response to requests, custom endpoints give you more control over what you return.
+DADI API custom endpoints give you the ability to modify, enrich and massage your data before it is returned to the user making the request. Collection endpoints return raw data in response to requests, whereas custom endpoints give you more control over what you return.
 
 #### Endpoint Specification
 
-Endpoint specifications are simply Javascript files stored in your application's `/workspace/endpoints` folder. It is important to understand how the folder hierarchy in the endpoints folder affects the behaviour of your API.
+Endpoint specifications are simply JavaScript files stored in your application's `/workspace/endpoints` folder. It is important to understand how the folder hierarchy in the endpoints folder affects the behaviour of your API.
 
 
 ```
@@ -1395,7 +1468,7 @@ my-api/
 
 #### Endpoint
 
-Endpoint specifications exist as Javascript files within a `version` folder as mentioned above. The naming convention for the collection specifications is `endpoint.<endpoint name>.js`
+Endpoint specifications exist as JavaScript files within a `version` folder as mentioned above. The naming convention for the collection specifications is `endpoint.<endpoint name>.js`
 
 #### Endpoint URL
 
@@ -1408,7 +1481,6 @@ In actual use this might look like the following:
 `https://api.somedomain.tech/1.0/booksByAuthor`
 
 #### The Endpoint file
-
 
 Endpoint specification files should export functions with lowercase names that correspond to the HTTP method that the function is designed to handle.
 
@@ -1455,18 +1527,9 @@ module.exports.get = function (req, res, next) {
 
 ```js
 module.exports.get = function (req, res, next) {
-  let data = {
-    results: [
-      {
-        title: 'Book One',
-        author: 'Benjamin Franklin'
-      }
-    ]
-  }
-
   res.setHeader('content-type', 'application/json')
-  res.statusCode = 200
-  res.end(JSON.stringify(data))
+  res.statusCode = 404
+  res.end()
 }
 ```
 
@@ -1474,18 +1537,15 @@ module.exports.get = function (req, res, next) {
 
 ```js
 module.exports.get = function (req, res, next) {
-  let data = {
-    results: [
-      {
-        title: 'Book One',
-        author: 'Benjamin Franklin'
-      }
+  let error = {
+    errors: [
+      'An error occured while processing your request'
     ]
   }
 
   res.setHeader('content-type', 'application/json')
-  res.statusCode = 200
-  res.end(JSON.stringify(data))
+  res.statusCode = 500
+  res.end(JSON.stringify(error))
 }
 ```
 
@@ -1525,26 +1585,17 @@ module.exports.model.settings = { authenticate : false }
 ```
 
 
-#### Endpoint GET request
-
-This will return a "Hello World" example -
-
-```
-GET /v1/test-endpoint HTTP/1.1
-Host: api.somedomain.tech
-content-type: application/json
-Authorization: Bearer 171c8c12-6e9b-47a8-be29-0524070b0c65
-```
-
-#### Endpoint GET response
-
-```json
-{ "message": "Hello World" }
-```
-
 ### Hooks
 
 Hooks perform operations on data before/after GET, UPDATE and DELETE requests. In essence, a hook is simply a function that intercepts a document/query before it's executed, having the option to modify it before returning it back to the model.
+
+#### Use cases
+
+- Creating variations of a field, such as creating a slug (example above);
+- Validating fields with complex conditions, when a regular expression might not be enough;
+- Triggering an action, notification or external command when a record is modified.
+
+#### Anatomy of a hook
 
 A hook is stored as an individual file in a `hooks` directory (defaulting to `/workspace/hooks`) and can be used by being attached to `create`, `update` or `delete` operations in the `settings` section of a collection schema specification.
 
@@ -1562,23 +1613,12 @@ This means that whenever a new user is created, the document that is about to be
 
 The order in which hooks are executed is defined by the order of the items in the array.
 
-#### Anatomy of a hook
-
-- one
-* two
-+ three
-
-A hook always receives 3 arguments:
-
-1. `obj`: The main object, which the hook is able to modify. It must always return it back. It can be a document (on `create`) or a query (on `update` or `delete`);
-2. `type`: The type of hook. Can be `0` (`create`), `1` (`update`) or `2` (`delete`);
-3. `data`: Object that passed additional data, such as the `options` object that may be declared with the hook, or other objects depending on the type of hook (e.g. `updatedDocs` will be passed if it's a `update` hook).
-
-A simple hook can be defined as following:
+The following example defines a very simple hook, which will change the `name` field of a document before returning it.
 
 ```js
 module.exports = function (doc, type, data) {
   doc.name = 'Modified by the hook'
+
   return doc
 }
 ```
@@ -1605,7 +1645,7 @@ For that reason, developers might have the need to pass extra information to the
 }
 ```
 
-In this example we implement a hook that populates a field (`slug`) with a URL-friendly version of another field (`title`). The hook is created in such a way that the properties it reads from and writes to are dynamic, passed through as `from` and `to` inside `options`. The `slugify` hook could then be written as follows:
+In this example we implement a hook that populates a field (`slug`) with a URL-friendly version of another field (`title`). The hook is created in such a way that the properties it reads from and writes to are dynamic, passed through as `from` and `to` from the `options` block. The `slugify` hook can then be written as follows:
 
 ```js
 // Example hook: Creates a URL-friendly version (slug) of a field
@@ -1626,47 +1666,174 @@ module.exports = function (obj, type, data) {
 }
 ```
 
-#### Use cases
 
-- Creating variations of a field, such as creating a slug (example above);
-- Validating fields with complex conditions, when a regular expression might not be enough;
-- Converting different types of data to a unique format, such as Unixon timestamp;
-- Triggering an action, notification or external command when a record is modified
+#### *Before* and *After* Hooks
 
+Different types of hooks are executed at different points in the lifecycle of a request. There are two main types of hooks:
 
-#### Before and After Hooks
+- *Before* hooks: are always executed, fired just before the model processes the request and grabs the documents from the database. These hooks have the power to modify the query parameters, and therefore modify the set of documents that will be retrieved, as well as to abort an operation completely, if they choose to throw an error;
+- *After* hooks: are executed only if the operation has been successful (i.e. no errors resulting from either *before* hooks or from the communication with the database). They are fired after the result set has been formed and delivered to the consumer. *Before* hooks cannot affect the result of a request. Typically used to trigger operations that must take place after a set of documents has been successfully created, updated or deleted.
 
-*Before* hooks are always fired, whereas *after* hooks only fire after and if an operation is successful.
+These hook types are then applied to each of the CRUD operations (e.g. `beforeCreate`, `afterCreate`, etc.). If you think of API as an assembly line that processes requests and documents, this is where hooks would sit:
 
-#### Overview
+```
+         ______________          __________            _____________ 
+Request |              |        |          | Response |             |
+------> | beforeCreate | -----> | Database | -------> | afterCreate |
+        |______________|        |__________|          |_____________|
+```
 
-The following data is passed to each type of hook:
+#### Types and signatures
 
-- `beforeCreate`:
-   - `obj`: Fields sent in the request
-   - `data`:
-      - `options`: Hook options
-- `afterCreate`:
-   - `obj`: Document created in the database
-   - `data`:
-      - `options`: Hook options
-- `beforeUpdate`:
-   - `obj`: Update query sent in the request
-   - `data`:
-      - `options`: Hook options
-      - `updatedDocs`: Documents affected by the update
-- `afterUpdate`:
-   - `obj`: Updated documents
-   - `data`:
-      - `options`: Hook options
-- `beforeDelete`:
-   - `obj`: Delete query sent in the request
-   - `data`:
-      - `options`: Hook options
-- `afterDelete`:
-   - `obj`: Delete query sent in the request
-   - `data`:
-      - `options`: Hook options
+Hooks are expected to export a function that receives three parameters:
+
+1. The document or query being processed (type: `Object`)
+1. The name of the hook type (type: `String`, example: `"beforeCreate"`)
+1. An object with additional data that varies with each hook type (type: `Object`)
+
+##### `beforeCreate`
+
+Fires for `POST` requests, before documents are inserted into the database.
+
+*Parameters:*
+
+1. `documents`: An object or array of objects representing the documents about to be created
+1. `type`: A string containing `"beforeCreate"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `req`: the instance of Node's [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  - `schema`: the schema of the current collection
+
+*Returns:*
+
+The new set of documents to be inserted. An error can be thrown to abort the operation.
+
+##### `afterCreate`
+
+Fires for `POST` requests, if and after the documents have been successfully inserted.
+
+*Parameters:*
+
+1. `documents`: An object or array of objects representing the documents created
+1. `type`: A string containing `"afterCreate"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `schema`: the schema of the current collection
+
+*Returns:*
+
+N/A
+
+##### `beforeDelete`
+
+Fires for `DELETE` requests, before data is deleted from the database.
+
+*Parameters:*
+
+1. `query`: A query that will be used to filter documents for deletion
+1. `type`: A string containing `"beforeDelete"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `req`: the instance of Node's [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  - `schema`: the schema of the current collection
+  - `deletedDocs`: an array containing the documents that are about to be deleted
+
+*Returns:*
+
+The new query to filter documents with. An error can be thrown to abort the operation.
+
+##### `afterDelete`
+
+Fires for `DELETE` requests, if and after the documents have been successfully deleted.
+
+*Parameters:*
+
+1. `query`: A query that was used to filter documents for deletion
+1. `type`: A string containing `"afterDelete"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `schema`: the schema of the current collection
+  - `deletedDocs`: an array containing the documents that are about to be deleted
+
+*Returns:*
+
+N/A
+
+##### `beforeGet`
+
+Fires for `GET` requests, before documents are retrieved from the database.
+
+*Parameters:*
+
+1. `query`: A query that will be used to filter documents
+1. `type`: A string containing `"beforeGet"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `req`: the instance of Node's [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  - `schema`: the schema of the current collection
+
+*Returns:*
+
+The new query to filter documents with. An error can be thrown to abort the operation.
+
+##### `afterGet`
+
+Fires for `GET` requests. Unlike other *after* hooks, *afterGet* happens after the data has been retrieved but before the response is sent to the consumer. As a consequence, *afterGet* hooks have the ability to massage the data before it's delivered.
+
+*Parameters:*
+
+1. `documents`: An object or array of objects representing the documents retrieved
+1. `type`: A string containing `"afterGet"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `req`: the instance of Node's [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  - `schema`: the schema of the current collection
+
+*Returns:*
+
+The result set formatted for output. An error can be thrown to abort the operation.
+
+##### `beforeUpdate`
+
+Fires for `PUT` requests, before documents are updated on the database.
+
+*Parameters:*
+
+1. `update`: An object with the set of fields to be updated and their respective new values
+1. `type`: A string containing `"beforeUpdate"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `req`: the instance of Node's [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  - `schema`: the schema of the current collection
+  - `updatedDocs`: the documents about to be updated
+
+*Returns:*
+
+The new update object. An error can be thrown to abort the operation.
+
+##### `afterUpdate`
+
+Fires for `PUT` requests, if and after the documents have been successfully updated.
+
+*Parameters:*
+
+1. `documents`: An object or array of objects representing the documents updated
+1. `type`: A string containing `"afterUpdate"`
+1. `options`: An options object containing:
+  - `collection`: name of the current collection
+  - `options`: options block from the hook definition in the collection schema
+  - `schema`: the schema of the current collection
+
+*Returns:*
+
+N/A
 
 #### Testing
 
@@ -1677,8 +1844,7 @@ The following hook may be useful to get a better idea of when exactly each hook 
 ```js
 module.exports = function (obj, type, data) {
   console.log('')
-  console.log('**** HOOK ***')
-  console.log('Type:', type)
+  console.log('Hook type:', type)
   console.log('Payload:', obj)
   console.log('Additional data:', data)
   console.log('')
@@ -1706,13 +1872,19 @@ And then enable it in a model:
 
 ### Hello
 
-
+The *Hello* endpoint returns a plain text response with the string *Welcome to API* when a `GET` request is made to the `/hello` endpoint. It can be used to verify that DADI API was successfully installed.
 
 ### Configuration
+
+[TODO]
+
 ### Cache flush
+
+[TODO]
+
 ### All Collections
 
-A document containing information about the available collections can be retrieved by sending a GET request to the API's `/api/collections` endpoint.
+A document containing information about the available collections can be retrieved by sending a `GET` request to the API's `/api/collections` endpoint.
 
 ```http
 GET /api/collections HTTP/1.1
@@ -1755,7 +1927,6 @@ Cache-Control: no-cache
 
 The MongoDB connector allows you to use MongoDB as the backend for API.
 
-
 Help improve the package at https://github.com/dadi/api-mongodb.
 
 
@@ -1767,15 +1938,19 @@ $ npm install --save @dadi/api-mongodb
 
 #### Configuring
 
+[TODO]
+
 #### Using MongoLab
+
+[TODO]
 
 ### CouchDB Connector
 
 The CouchDB connector allows you to use CouchDB as the backend for API.
 
 Help improve the package at https://github.com/dadi/api-couchdb.
-#### Installing
 
+#### Installing
 
 ```console
 $ npm install --save @dadi/api-couchdb
@@ -1797,13 +1972,11 @@ $ npm install --save @dadi/api-filestore
 
 Sample repository at https://github.com/dadi/api-connector-template.
 
-
 ## How-to guides
 
+### Connecting to API with API wrapper
 
-### Connecting to API
-
-### Data connectors
+[TODO]
 
 ### Auto generate documentation
 
@@ -1931,14 +2104,13 @@ To show example data in the documentation that isn't simply the default of "Hell
 See a list of available options [here](https://github.com/FotoVerite/Faker.js).
 
 
-#### Excluding Collections, Endpoints and Fields
+#### Excluding collections, endpoints and fields
 
-Often an API contains collections and collection fields that are meant for
-internal use and including them in the API documentation is undesirable.
+Often an API contains collections and collection fields that are meant for internal use and including them in the API documentation is undesirable.
 
 To exclude collections and fields from your generated documentation, see the following sections.
 
-##### Excluding Collections
+##### Excluding collections
 
 Add a `private` property to the collection specification's `settings` section:
 
@@ -1966,7 +2138,7 @@ Add a `private` property to the collection specification's `settings` section:
 }
 ```
 
-##### Excluding Endpoints
+##### Excluding endpoints
 
 Add a `private` property to the endpoint file's `model.settings` section:
 
@@ -1986,7 +2158,7 @@ module.exports.model = {
 }
 ```
 
-##### Excluding Fields
+##### Excluding fields
 
 Add a `private` property to the field specification:
 
@@ -2028,6 +2200,7 @@ You received an error similar to this:
 }
 ```
 
+[TODO]
 
 ### API-0002
 
@@ -2047,6 +2220,8 @@ You received an error similar to this:
   ]
 }
 ```
+
+[TODO]
 
 ### API-0003
 
@@ -2077,9 +2252,6 @@ A successful cache flush returns a HTTP 200 response:
 ##### Flush all files
 
 To flush all cache files, send `{ path: "*" }`
-
-
-## How-to guides
 
 ### Migrating from version 2.x to 3.x
 

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -1737,12 +1737,12 @@ Different types of hooks are executed at different points in the lifecycle of a 
 
 These hook types are then applied to each of the CRUD operations (e.g. `beforeCreate`, `afterCreate`, etc.). If you think of API as an assembly line that processes requests and documents, this is where hooks would sit:
 
-```text
+<pre>
          ______________          __________            _____________ 
 Request |              |        |          | Response |             |
 ------> | beforeCreate | -----> | Database | -------> | afterCreate |
         |______________|        |__________|          |_____________|
-```
+</pre>
 
 #### Types and signatures
 

--- a/docs/api/1.3.0.md
+++ b/docs/api/1.3.0.md
@@ -946,10 +946,10 @@ If the setting is `true` – that is, the main configuration file contains `"fee
 
 ```json
 {
-  status: 'success',
-  message: 'Documents deleted successfully',
-  deletedCount: 1,
-  totalCount: 99
+  "status": "success",
+  "message": "Documents deleted successfully",
+  "deletedCount": 1,
+  "totalCount": 99
 }
 ```
 


### PR DESCRIPTION
Missing sections:

- [x] Retrieving data
- [x] Internal endpoints / Configuration
- [x] Internal endpoints / Cache flush
- [ ] MongoDB connector / Configuring
- [ ] MongoDB connector / Using MongoLab
- [x] How-to guides / Connecting to API using API wrapper

API 3.1 changes:

- [ ] Settings block no longer required
- [ ] Document DateTime field
- [ ] `$now`
- [ ] New Model API
- [ ] Updates to Reference fields (new values for `compose`, multi-collection, at-notation in queries)