### PR TITLE
Add API 3.1 docs

### DIFF
--- a/docs/api/3.0.0.md
+++ b/docs/api/3.0.0.md
@@ -404,7 +404,7 @@ All requests to collection and custom endpoints must include the version in the 
 
 Collection documents may be stored in separate databases in the underlying data store, represented by the name of the "database" directory.
 
-> **Note** This feature is disabled by default. To enable separate databases in your API the configuration setting `database.enableCollectionDatabases` must be `true`. See [Collection-specific Databases](#collection-specific-databases) for more information.
+> **Note:** This feature is disabled by default. To enable separate databases in your API the configuration setting `database.enableCollectionDatabases` must be `true`. See [Collection-specific Databases](#collection-specific-databases) for more information.
 
 **Collection specification file**
 
@@ -1668,19 +1668,19 @@ Two revision documents stored in the revision collection — one created at the 
 
 ## Document Composition
 
-To reduce data duplication caused by embedding subdocuments, DADI API allows the use of "Reference" fields which can best be described as pointers to other documents. The referenced document could be in the same collection, another collection in the same database or a collection in a different database.
+To reduce data duplication caused by embedding sub-documents, DADI API allows the use of *Reference* fields which can best be described as pointers to other documents, which could be in the same collection, another collection in the same database or a collection in a different database.
 
 **Reference Field Settings**
 
 | Property       | Description        |   Example
 |:----------------|:-------------------|:-------
-| database | The name of the database that holds the reference data. Can be omitted if the field references data in the same **database** as the referring document. | `"library"`
-| collection | The name of the collection that holds the reference data. Can be omitted if the field references data in the same **collection** as the referring document. | `"people"`
+| database | The name of the database that holds the reference data. Can be omitted if the field references data in the same database as the referring document. | `"library"`
+| collection | The name of the collection that holds the reference data. Can be omitted if the field references data in the same collection as the referring document, or if the field references documents from multiple collections. | `"people"`
 | fields  | An array of fields to return for each referenced document.   | `["firstName", "lastName"]`
 
-### Example
+### A simple example
 
-Consider the following two collections, `books` and `people`. `books` contains a Reference field `author` which is capable of loading documents from the `people` collection. By creating a `book` document and setting the `author` field to the `_id` value of a document from the `people` collection, API is able to resolve the reference and return the `author` as a subdocument within the response for a `books` query.
+Consider the following two collections: `books` and `people`. `books` contains a *Reference* field `author` which is capable of loading documents from the `people` collection. By creating a `book` document and setting the `author` field to the `_id` value of a document from the `people` collection, API is able to resolve the reference and return the `author` as a subdocument within the response for a `books` query.
 
 **Books `(collection.books.json)`**
 
@@ -1688,25 +1688,14 @@ Consider the following two collections, `books` and `people`. `books` contains a
 {
   "fields": {
     "title": {
-      "type": "String",
-      "required": true
+      "type": "String"
     },
     "author": {
       "type": "Reference",
       "settings": {
-        "collection": "people",
-        "fields": ["firstName", "lastName"]
+        "collection": "people"
       }
-    },
-    "booksInSeries": {
-      "type": "Reference"
     }
-  },
-  "settings": {
-    "cache": true,
-    "count": 40,
-    "sort": "title",
-    "sortOrder": 1
   }
 }
 ```
@@ -1717,34 +1706,420 @@ Consider the following two collections, `books` and `people`. `books` contains a
 {
   "fields": {
     "name": {
-      "type": "String",
-      "required": true
-    },
-    "occupation":	{
-      "type": "String",
-      "required": false
-    },
-    "nationality": {
-      "type": "String",
-      "required": false
-    },
-    "education": {
-      "type": "String",
-      "required": false
-    },
-    "spouse": {
-      "type": "Reference"
+      "type": "String"
     }
-  },
-  "settings": {
-    "cache": true,
-    "count": 40,
-    "sort": "name",
-    "sortOrder": 1
   }
 }
 ```
 
+**Request**
+
+```http
+POST /1.0/library/books HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+{ "title": "For Whom The Bell Tolls", "author": "560a5baf320039f7d6a78d4a" }
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a3b68d4c",
+      "_composed": {
+        "author": "560a5baf320039f7d6a78d4a"
+      },
+      "author": {
+        "_id": "560a5baf320039f7d6a78d4a",
+        "name": "Ernest Hemingway"
+      }
+    }
+  ]
+}
+```
+
+### Enabling composition
+
+> **Note**
+>
+> By default, referenced documents will **not** be resolved and the raw document IDs will be shown in the response. This is by design, since resolving documents adds additional load to the processing of a request and therefore it's important that developers actively enable it only when necessary.
+>
+> -- warning
+
+Composition is the feature that allows API to resolve referenced documents before the response is delivered to the consumer. It means transforming document IDs into the actual content of the documents being referenced, and it can take place recursively for any number of levels – e.g. `{"author": "X"}` resolves to a document from the `people` collection, which in its turn may resolve `{"country": "Y"}` to a document from the `countries` collection, and so on.
+
+API will resolve a referenced document for a particular level if the referenced collection has `settings.compose: true` in its schema file *or* if there is a `compose` URL parameter that overrides that behaviour.
+
+The value of `compose` can be:
+
+- `false`: Stops any referenced documents from being resolved
+- `true`: Resolves all referenced documents for the current level; behaviour for nested levels depends on the value of `settings.compose` of the respective collections
+- a number (e.g. `compose=N`): Resolves all referenced documents for `N` number of levels, including the current one
+- `all`: Resolves all referenced documents for all levels
+
+### The `_composed` property
+
+When a document ID is resolved into a referenced document, the raw value of the *Reference* field is added to a `_composed` internal property. This allows consumers to determine that the result of a given field differs from its actual internal representation, which can still be accessed via the `_composed` property, if needed.
+
+### Referencing one or multiple documents
+
+Reference fields can link to one or multiple documents, depending on whether the input data is an ID or an array of IDs. The input format is respected in the composed response.
+
+**Request**
+
+```http
+POST /1.0/library/books HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+[
+  { "title": "For Whom The Bell Tolls", "author": "560a5baf320039f7d6a78d4a" },
+  { "title": "Nightfall", "author": [ "560a5baf320039f7d6a78d1a", "560a5baf320039f7d6a78d1a" ] }
+]
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a3b68d4c",
+      "_composed": {
+        "author": "560a5baf320039f7d6a78d4a"
+      },
+      "title": "For Whom The Bell Tolls",
+      "author": {
+        "_id": "560a5baf320039f7d6a78d4a",
+        "name": "Ernest Hemingway"
+      }
+    },
+    {
+      "_id": "560a5baf320039f1a3b68d4d",
+      "_composed": {
+        "author": [
+          "560a5baf320039f7d6a78d1a",
+          "560a5baf320039f7d6a78d1a" 
+        ]
+      }
+      "title": "Nightfall",
+      "author": [
+        {
+          "_id": "560a5baf320039f7d6a78d1a",
+          "name": "Jake Halpern"
+        },
+        {
+          "_id": "560a5baf320039f7d6a78d1b",
+          "name": "Peter Kujawinski"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Multi-collection references
+
+Rather than referencing documents from a collection that is pre-defined in the `settings.collection` property of the field schema, a single field can reference documents from multiple collections. If the input data is an object (or array of objects) with a `_collection` and `_data` properties, then the corresponding values will be used to determine the collection and ID of each referenced document.
+
+**Movies `(collection.movies.json)`**
+
+```json
+{
+  "fields": {
+    "title": {
+      "type": "String"
+    },
+    "crew": {
+      "type": "Reference"
+    }
+  }
+}
+```
+
+**Directors `(collection.directors.json)`**, **Producers `(collection.producers.json)`** and **Writers `(collection.writers.json)`**:
+
+```json
+{
+  "fields": {
+    "name": {
+      "type": "String"
+    }
+  }
+}
+```
+
+**Request**
+
+```http
+POST /1.0/library/movies HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+{
+  "title": "Casablanca",
+  "crew": [
+    {
+      "_collection": "writers",
+      "_data": "5ac16b70bd0d9b7724b24a41"
+    },
+    {
+      "_collection": "directors",
+      "_data": "5ac16b70bd0d9b7724b24a42"
+    },
+    {
+      "_collection": "producers",
+      "_data": "5ac16b70bd0d9b7724b24a43"
+    }
+  ]
+}
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a1b68d4c",
+      "_composed": {
+        "crew": [
+          "5ac16b70bd0d9b7724b24a41",
+          "5ac16b70bd0d9b7724b24a42",
+          "5ac16b70bd0d9b7724b24a43"
+        ]
+      },
+      "_refCrew": {
+        "5ac16b70bd0d9b7724b24a41": "writers",
+        "5ac16b70bd0d9b7724b24a42": "directors",
+        "5ac16b70bd0d9b7724b24a43": "producers"
+      },
+      "title": "Casablanca",
+      "crew": [
+        {
+          "_id": "5ac16b70bd0d9b7724b24a41",
+          "name": "Julius J. Epstein"
+        },
+        {
+          "_id": "5ac16b70bd0d9b7724b24a42",
+          "name": "Michael Curtiz"
+        },
+        {
+          "_id": "5ac16b70bd0d9b7724b24a43",
+          "name": "Hal B. Wallis"
+        }
+      ]
+    }
+}
+```
+
+Note the presence of `_refCrew` in the response. This is an internal field that maps document IDs to the names of the collections they belong to, as that information is not possible to extract from the resolved documents.
+
+### Pre-composed documents
+
+Setting the content of a Reference field to one or multiple document IDs is the simplest way of referencing documents, but it creates some complexity for consumer apps that wish to insert multiple levels of referenced documents.
+
+For example, imagine that you want to create a book *and* its author. You would:
+
+1. Create the author document
+1. Grab the document ID from step 1 and add it to the `author` property of a new book
+1. Create the book document
+
+You can see how this would get increasingly complex if you wanted to insert more levels. To address that, and as an alternative to receiving just document IDs, API is capable of processing a pre-composed set of documents and figure out what to do with the data, including creating and updating documents, as well as populating Reference fields with the right document IDs.
+
+#### Creating documents
+
+When the content of a Reference field is an object *without* an ID, a corresponding document is created in the collection defined by the `settings.collection` property of the field schema. If an array is sent, multiple documents will be created.
+
+**Request**
+
+```http
+POST /1.0/library/books HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+[
+  {
+    "title": "For Whom The Bell Tolls",
+    "author": { "name": "Ernest Hemingway" }
+  },
+  {
+    "title": "Nightfall",
+    "author": [
+      { "name": "Jake Halpern" },
+      { "name": "Peter Kujawinski" }
+    ]
+  }
+]
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a3b68d4c",
+      "_composed": {
+        "author": "560a5baf320039f7d6a78d4a"
+      },
+      "title": "For Whom The Bell Tolls",
+      "author": {
+        "_id": "560a5baf320039f7d6a78d4a",
+        "name": "Ernest Hemingway"
+      }
+    },
+    {
+      "_id": "560a5baf320039f1a3b68d4d",
+      "_composed": {
+        "author": [
+          "560a5baf320039f7d6a78d1a",
+          "560a5baf320039f7d6a78d1b"
+        ]
+      },
+      "title": "Nightfall",
+      "author": [
+        {
+          "_id": "560a5baf320039f7d6a78d1a",
+          "name": "Jake Halpern"
+        },
+        {
+          "_id": "560a5baf320039f7d6a78d1b",
+          "name": "Peter Kujawinski"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Updating documents
+
+When the content of a Reference field is an object *with* an ID, API updates the document referenced by that ID with the new sub-document.
+
+The example below creates a new book and sets an existing document (`560a5baf320039f7d6a78d4a`) as its author, but it also makes an update to the referenced document – in this case, `name` is changed to `"Ernest Miller Hemingway"`.
+
+**Request**
+
+```http
+POST /1.0/library/books HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+[
+  {
+    "title": "For Whom The Bell Tolls",
+    "author": {
+      "_id": "560a5baf320039f7d6a78d4a",
+      "name": "Ernest Miller Hemingway"
+    }
+  }
+]
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a3b68d4c",
+      "_composed": {
+        "author": "560a5baf320039f7d6a78d4a"
+      },
+      "title": "For Whom The Bell Tolls",
+      "author": {
+        "_id": "560a5baf320039f7d6a78d4a",
+        "name": "Ernest Miller Hemingway"
+      }
+    }
+  ]
+}
+```
+
+#### Multi-collection references
+
+It's possible to insert pre-composed documents that use the multi-collection reference syntax, as long as the pre-composed documents are inside the `_data` property of the outermost object in the Reference field value.
+
+The example below shows how the various scenarios can be mixed and matched: the first element of `crew` is a new document to be created in the `writers` collection (no ID); the second item is a document ID, which will be stored as is in the `directors` collection; the third item references an existing document from the `producers` collection, whose `name` will be updated to a new value.
+
+**Request**
+
+```http
+POST /1.0/library/movies HTTP/1.1
+Host: api.somedomain.tech
+Authorization: Bearer 4172bbf1-0890-41c7-b0db-477095a288b6
+Content-Type: application/json
+
+{
+  "title": "Casablanca",
+  "crew": [
+    {
+      "_collection": "writers",
+      "_data": {
+        "name": "Julius J. Epstein"
+      }
+    },
+    {
+      "_collection": "directors",
+      "_data": "5ac16b70bd0d9b7724b24a42"
+    },
+    {
+      "_collection": "producers",
+      "_data": {
+        "_id": "5ac16b70bd0d9b7724b24a43",
+        "name": "Hal Brent Wallis"
+      }
+    }
+  ]
+}
+```
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "_id": "560a5baf320039f1a1b68d4c",
+      "_composed": {
+        "crew": [
+          "5ac16b70bd0d9b7724b24a41",
+          "5ac16b70bd0d9b7724b24a42",
+          "5ac16b70bd0d9b7724b24a43"
+        ]
+      },
+      "_refCrew": {
+        "5ac16b70bd0d9b7724b24a41": "writers",
+        "5ac16b70bd0d9b7724b24a42": "directors",
+        "5ac16b70bd0d9b7724b24a43": "producers"
+      },
+      "title": "Casablanca",
+      "crew": [
+        {
+          "_id": "5ac16b70bd0d9b7724b24a41",
+          "name": "Julius J. Epstein"
+        },
+        {
+          "_id": "5ac16b70bd0d9b7724b24a42",
+          "name": "Michael Curtiz"
+        },
+        {
+          "_id": "5ac16b70bd0d9b7724b24a43",
+          "name": "Hal Brent Wallis"
+        }
+      ]
+    }
+}
+```
 
 ### Composed
 


### PR DESCRIPTION
- [x] Settings block no longer required
- [x] Document DateTime field
- [x] `$now`
- [x] New Model API
- [x] Updates to Reference fields (new values for `compose`, multi-collection, at-notation in queries)