### PR TITLE
Ensure upload posts to '/media/upload'

### DIFF
--- a/docs/api/4.3.md
+++ b/docs/api/4.3.md
@@ -3550,20 +3550,21 @@ To upload a file send a `multipart/form-data` POST to the media collection's end
 curl -X POST
   -H "Content-Type: multipart/form-data"
   -H "Authorization: Bearer 8df4a823-1e1e-4bc4-800c-97bb480ccbbe"
-  -F "data=@/Users/userName/images/my-image.jpg" "http://api.somedomain.tech/media"
+  -F "data=@/Users/userName/images/my-image.jpg" "http://api.somedomain.tech/media/upload"
 ```
 
 #### Uploading a file with Node.js
 
 ```js
 const FormData = require('form-data')
+const config = require('@dadi/web').Config
 
 let options = {
-  host: 'api.somedomain.tech',
-  port: 80,
-  path: '/media',
+  host: config.get('api.host'),
+  port: config.get('api.port'),
+  path: '/media/upload',
   headers: {
-    'Authorization': 'Bearer 8df4a823-1e1e-4bc4-800c-97bb480ccbbe',
+    'Authorization': 'Bearer 8df4a823-1e1e-4bc4-800c-97bb480ccbbe', // can be generated using '@dadi/passport'
     'Accept': 'application/json'
   }
 }


### PR DESCRIPTION
Documentation originally used '/media' which was causing an error