### PR TITLE
Fix ACL client.get example

### DIFF
--- a/docs/api/5.0.md
+++ b/docs/api/5.0.md
@@ -1778,16 +1778,14 @@ If `secret` is passed as a second argument, only a client that matches both the 
 ```js
 const ACL = require('@dadi/api').ACL
 
-ACL.client.get({
-  clientId: 'restfulJohn',
-  secret: 'superSecret!'
-}).then(({results}) => {
-  if (results.length === 0) {
-    return console.log('Wrong credentials!')
-  }
+ACL.client.get('restfulJohn', 'superSecret!')
+  .then(({results}) => {
+    if (results.length === 0) {
+      return console.log('Wrong credentials!')
+    }
 
-  console.log(results[0])
-})
+    console.log(results[0])
+  })
 ```
 
 #### client.resourceAdd


### PR DESCRIPTION
The method signature is actually `function (clientId, secret)`